### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Seg7/keywords.txt
+++ b/Seg7/keywords.txt
@@ -1,5 +1,5 @@
-Seg7	    KEYWORD1
+Seg7	KEYWORD1
 
-attach	    KEYWORD2
-write	    KEYWORD2
-set_cathode KEYWORD2
+attach	KEYWORD2
+write	KEYWORD2
+set_cathode	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords